### PR TITLE
The exclusion path setting should also apply to the paths of newly created attachment files.…

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -103,7 +103,7 @@ export default class PasteImageRenamePlugin extends Plugin {
 						}
 						const activeFile = this.getActiveFile()
 						if (this.testExcludePath(activeFile, file)) {
-							debugLog("excluded file by path", activeFile);
+							debugLog('excluded file by path', activeFile)
 							return;
 						}
 						this.startRenameProcess(file, this.settings.autoRename)

--- a/src/main.ts
+++ b/src/main.ts
@@ -89,7 +89,7 @@ export default class PasteImageRenamePlugin extends Plugin {
 				if (isPastedImage(file)) {
 					debugLog('pasted image created', file)
 					const activeFile = this.getActiveFile()
-					if (this.testExcludePath(activeFile)) {
+					if (this.testExcludePath(activeFile, file)) {
 						debugLog('excluded file by path', activeFile)
 						return
 					}
@@ -102,9 +102,9 @@ export default class PasteImageRenamePlugin extends Plugin {
 							return
 						}
 						const activeFile = this.getActiveFile()
-						if (this.testExcludePath(activeFile)) {
-							debugLog('excluded file by path', activeFile)
-							return
+						if (this.testExcludePath(activeFile, file)) {
+							debugLog("excluded file by path", activeFile);
+							return;
 						}
 						this.startRenameProcess(file, this.settings.autoRename)
 					}
@@ -384,11 +384,14 @@ export default class PasteImageRenamePlugin extends Plugin {
 		if (!pattern) return false
 		return new RegExp(pattern).test(file.extension)
 	}
-	testExcludePath(file: TFile): boolean {
-		const pattern = this.settings.excludePathPattern
-		if (!pattern) return false
-		debugLog('file path', file.path)
-		return new RegExp(pattern).test(file.path)
+
+	testExcludePath(activeFile: TFile, attachmentFile: TFile): boolean {
+    const pattern = this.settings.excludePathPattern;
+    if (!pattern) return false;
+    const regex = new RegExp(pattern);
+    debugLog("activeFile path", activeFile.path);
+    debugLog("attachmentFile path", attachmentFile.path);
+    return regex.test(activeFile.path) || regex.test(attachmentFile.path);
 	}
 
 	async loadSettings() {


### PR DESCRIPTION
exclusion path setting is great but it still have problem when I dont open any file and then add attachment manually then they still renamed. This pr should fix it. please merged this and wait for the original author merge yours PR.